### PR TITLE
allow stacked line graphs in wijcompositechart

### DIFF
--- a/wijmo/jquery.wijmo.wijcompositechart.js
+++ b/wijmo/jquery.wijmo.wijcompositechart.js
@@ -1249,6 +1249,7 @@
 								self.aniPathsAttr = [];
 							}
 							tmpOptions = $.extend(true, {}, options, {
+								stacked: o.stacked,
 								axis: o.axis,
 								isXTime: self.axisInfo.x.isTime,
 								isYTime: self.axisInfo.y[0].isTime,


### PR DESCRIPTION
I tested this in the wijmo.wijcompositechart.js included in the demo download, which I found before I found this repo.  There appear to be some differences between this version and that one, but the update is so simple, I believe it should still work.
